### PR TITLE
Fix off by one in sourceirc-rcon

### DIFF
--- a/scripting/SourceIRC/sourceirc-rcon.sp
+++ b/scripting/SourceIRC/sourceirc-rcon.sp
@@ -100,7 +100,7 @@ public OnSocketReceive(Handle:socket, String:receiveData[], const dataSize, any:
 		if (serverdata == 0 && requestid > 1) {
 			decl String:lines[64][256];
 			new linecount = ExplodeString(receiveData[i+12], "\n", lines, sizeof(lines), sizeof(lines[]));
-			for (new l = 0; l <= linecount; l++) {
+			for (new l = 0; l < linecount; l++) {
 				IRC_ReplyToCommand(greplynick, "%s", lines[l]);
 			}
 			busy = false;


### PR DESCRIPTION
Off by one error. When the index l is equal to the length of the array linecount, lines[l] will be out of bounds. The highest valid index will be length - 1.

<Alex> I think rcon to trade has died.
<Alex> hmm
<Alex> Ew, wtf?
<Alex> it broke when I typed 'maps *'
<Alex> L 10/03/2014 - 15:46:25: [SM] Plugin encountered error 15: Array index is out of bounds
<Alex> L 10/03/2014 - 15:46:25: [SM] Displaying call stack trace for plugin "SourceIRC/sourceirc-rcon.smx":
<Alex> L 10/03/2014 - 15:46:25: [SM]   [0]  Line 104, scripting/SourceIRC/sourceirc-rcon.sp::OnSocketReceive()
